### PR TITLE
Install with setuptools aka pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # Smart-Mirror
 Raspberry powered mirror which can display the news, weather, and time.
 
+## Installation and Updating
+Installation is simple as running the following command.
+
+> sudo pip install git+https://github.com/HackerHouseYT/Smart-Mirror.git
+
+## Running
+To run the application run the following command
+> python -m smartmirror
+
 [![Link to youtube how-to video](http://i.imgur.com/cMyaSHT.png)](https://youtu.be/fkVBAcvbrjU)

--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ Installation is simple as running the following command.
 To run the application run the following command
 > python -m smartmirror
 
+## Demo and Build Instructions
 [![Link to youtube how-to video](http://i.imgur.com/cMyaSHT.png)](https://youtu.be/fkVBAcvbrjU)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Installation is simple as running the following command.
 > sudo pip install git+https://github.com/HackerHouseYT/Smart-Mirror.git
 
 ## Running
-To run the application run the following command
-> python -m smartmirror
+To run the application run the following command in this folder
+> python smartmirror.py
 
 ## Demo and Build Instructions
 [![Link to youtube how-to video](http://i.imgur.com/cMyaSHT.png)](https://youtu.be/fkVBAcvbrjU)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+feedparser
+Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-requests
-feedparser
-Pillow

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,13 @@ if os.getuid() != 0:
 print('INFO: Checking and installing requirements')
 os.system('! dpkg -S python-imaging-tk && apt-get -y install python-imaging-tk')
 
+# Generate the requirements from the file for old instructions
+print('INFO: Generating the requirements from requirements.txt')
+packages = []
+for line in open('requirements.txt', 'r'):
+    if not line.startswith('#'):
+        packages.append(line.strip())
+
 # Run setuptools for pip
 setup(
     name='smartmirror',
@@ -20,6 +27,6 @@ setup(
     description='Raspberry powered mirror which can display news, weather, calendar events',
     author='HackerHouse',
     url='https://github.com/HackerHouseYT/Smart-Mirror',
-    install_requires=['requests', 'feedparser', 'Pillow'],
-    packages = find_packages(),
+    install_requires=packages,
+    packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+
+import os
+import sys
+from setuptools import setup, find_packages
+
+# Must be ran as root or as sudo
+if os.getuid() != 0:
+    print('ERROR: Need to run as root')
+    sys.exit(1)
+
+# Install the requirements if the system does not have it installed
+print('INFO: Checking and installing requirements')
+os.system('! dpkg -S python-imaging-tk && apt-get -y install python-imaging-tk')
+
+# Run setuptools for pip
+setup(
+    name='smartmirror',
+    version='1.0.0',
+    description='Raspberry powered mirror which can display news, weather, calendar events',
+    author='HackerHouse',
+    url='https://github.com/HackerHouseYT/Smart-Mirror',
+    install_requires=['requests', 'feedparser', 'Pillow'],
+    packages = find_packages(),
+)


### PR DESCRIPTION
This adds the ability to install the smart mirror with one command.
This also makes the readme clear on what to do.

The following command will work once merged.
> sudo pip install git+https://github.com/HackerHouseYT/Smart-Mirror.git

To test this run the following command to trigger from my repo.
> sudo pip install git+https://github.com/ewized/Smart-Mirror.git@setuptools
